### PR TITLE
Feature/issue 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<version>0.8.14</version>
+			<scope>compile</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
@@ -1,8 +1,10 @@
 package com.jonassavas.spring_task_api.controllers;
 
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.mappers.Mapper;
@@ -12,6 +14,7 @@ import com.jonassavas.spring_task_api.services.TaskService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -55,4 +58,11 @@ public class TaskController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    // @PatchMapping(path = "/tasks/{id}")
+    // public ResponseEntity<TaskDto> update(@PathVariable Long id, @RequestBody CreateTaskDto dto){
+    //     TaskEntity updated = taskService.update(id, dto);
+        
+    //     return new ResponseEntity<>(CreateTaskMapper.mapTo());
+
+    // }
 }

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
@@ -51,7 +51,7 @@ public class TaskController {
 
     @DeleteMapping(path = "/tasks/{id}")
     public ResponseEntity deleteTask(@PathVariable("id") Long id){
-        taskService.deleteTask(id);
+        taskService.delete(id);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.mappers.Mapper;
+import com.jonassavas.spring_task_api.services.TaskGroupService;
 import com.jonassavas.spring_task_api.services.TaskService;
 
 import org.springframework.http.HttpStatus;
@@ -22,11 +23,13 @@ public class TaskController {
     
     private Mapper<TaskEntity, TaskDto> taskMapper;
     private TaskService taskService;
+    private TaskGroupService taskGroupService;
 
 
-    public TaskController(Mapper<TaskEntity, TaskDto> taskMapper, TaskService taskService){
+    public TaskController(Mapper<TaskEntity, TaskDto> taskMapper, TaskService taskService, TaskGroupService taskGroupService){
         this.taskMapper = taskMapper;
         this.taskService = taskService;
+        this.taskGroupService = taskGroupService;
     }
     
 
@@ -34,6 +37,11 @@ public class TaskController {
     public ResponseEntity<TaskDto> createTask(
             @PathVariable Long groupId,
             @RequestBody TaskDto dto) {
+
+        // Can't create a task without a valid task group
+        if(!taskGroupService.isExist(groupId)){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
         
         TaskEntity taskEntity = taskMapper.mapFrom(dto);
         TaskEntity savedTask = taskService.createTask(groupId, taskEntity);

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
@@ -1,10 +1,8 @@
 package com.jonassavas.spring_task_api.controllers;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskRequestDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.mappers.Mapper;
@@ -25,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public class TaskController {
     
     private Mapper<TaskEntity, TaskDto> taskMapper;
-    private Mapper<TaskEntity, CreateTaskDto> createTaskMapper;
+    private Mapper<TaskEntity, TaskRequestDto> taskRequestMapper;
     private TaskService taskService;
     private TaskGroupService taskGroupService;
 
@@ -33,11 +31,11 @@ public class TaskController {
     public TaskController(Mapper<TaskEntity, TaskDto> taskMapper, 
                         TaskService taskService, 
                         TaskGroupService taskGroupService,
-                        Mapper<TaskEntity, CreateTaskDto> createTaskMapper){
+                        Mapper<TaskEntity, TaskRequestDto> taskRequestMapper){
         this.taskMapper = taskMapper;
         this.taskService = taskService;
         this.taskGroupService = taskGroupService;
-        this.createTaskMapper = createTaskMapper;
+        this.taskRequestMapper = taskRequestMapper;
     }
     
 
@@ -64,9 +62,9 @@ public class TaskController {
     }
 
     @PatchMapping(path = "/tasks/{id}")
-    public ResponseEntity<CreateTaskDto> update(@PathVariable Long id, @RequestBody CreateTaskDto dto){
+    public ResponseEntity<TaskRequestDto> update(@PathVariable Long id, @RequestBody TaskRequestDto dto){
         TaskEntity updated = taskService.update(id, dto);
         
-        return new ResponseEntity<>(createTaskMapper.mapTo(updated), HttpStatus.OK);
+        return new ResponseEntity<>(taskRequestMapper.mapTo(updated), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskController.java
@@ -25,14 +25,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 public class TaskController {
     
     private Mapper<TaskEntity, TaskDto> taskMapper;
+    private Mapper<TaskEntity, CreateTaskDto> createTaskMapper;
     private TaskService taskService;
     private TaskGroupService taskGroupService;
 
 
-    public TaskController(Mapper<TaskEntity, TaskDto> taskMapper, TaskService taskService, TaskGroupService taskGroupService){
+    public TaskController(Mapper<TaskEntity, TaskDto> taskMapper, 
+                        TaskService taskService, 
+                        TaskGroupService taskGroupService,
+                        Mapper<TaskEntity, CreateTaskDto> createTaskMapper){
         this.taskMapper = taskMapper;
         this.taskService = taskService;
         this.taskGroupService = taskGroupService;
+        this.createTaskMapper = createTaskMapper;
     }
     
 
@@ -58,11 +63,10 @@ public class TaskController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    // @PatchMapping(path = "/tasks/{id}")
-    // public ResponseEntity<TaskDto> update(@PathVariable Long id, @RequestBody CreateTaskDto dto){
-    //     TaskEntity updated = taskService.update(id, dto);
+    @PatchMapping(path = "/tasks/{id}")
+    public ResponseEntity<CreateTaskDto> update(@PathVariable Long id, @RequestBody CreateTaskDto dto){
+        TaskEntity updated = taskService.update(id, dto);
         
-    //     return new ResponseEntity<>(CreateTaskMapper.mapTo());
-
-    // }
+        return new ResponseEntity<>(createTaskMapper.mapTo(updated), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskGroupDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskGroupWithTasksDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.mappers.Mapper;
@@ -47,11 +48,37 @@ public class TaskGroupController {
         return new ResponseEntity<>(createTaskGroupMapper.mapTo(savedTaskGroupEntity), HttpStatus.CREATED);
     }
 
-    @GetMapping(path = "/taskgroups")
+    @GetMapping("/taskgroups")
     public List<TaskGroupDto> listTaskGroups() {
-        List<TaskGroupEntity> taskGroups = taskGroupService.findAll();
-        return taskGroups.stream().map(taskGroupMapper::mapTo).collect(Collectors.toList());
+        return taskGroupService.findAll()
+            .stream()
+            .map(taskGroupMapper::mapTo)
+            .toList();
     }
+
+    // @GetMapping("/taskgroups/{id}/tasks")
+    // public List<TaskDto> listTasksForGroup(@PathVariable Long id) {
+    //     return taskService.findByGroupId(id)
+    //         .stream()
+    //         .map(taskMapper::mapTo)
+    //         .toList();
+    // }
+
+    // @GetMapping("/taskgroups/with-tasks")
+    //     public List<TaskGroupWithTasksDto> listTaskGroupsWithTasks() {
+    //         return taskGroupService.findAllWithTasks()
+    //             .stream()
+    //             .map(taskGroupWithTasksMapper::mapTo)
+    //             .toList();
+    //     }
+
+
+
+    // @GetMapping(path = "/taskgroups")
+    // public List<TaskGroupDto> listTaskGroups() {
+    //     List<TaskGroupEntity> taskGroups = taskGroupService.findAll();
+    //     return taskGroups.stream().map(taskGroupMapper::mapTo).collect(Collectors.toList());
+    // }
 
     @DeleteMapping(path = "/taskgroups/{id}")
     public ResponseEntity deleteTaskGroup(@PathVariable("id") Long id){

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
@@ -18,9 +18,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 
 @RestController
@@ -61,6 +63,12 @@ public class TaskGroupController {
     public ResponseEntity deleteAllTasks(@PathVariable("groupId") Long groupId){
         taskGroupService.deleteAllTasks(groupId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PatchMapping(path = "/taskgroups/{id}")
+    public ResponseEntity<CreateTaskGroupDto> updateTaskGroup(@PathVariable Long id, @RequestBody CreateTaskGroupDto dto){
+        TaskGroupEntity updated = taskGroupService.update(id, dto);
+        return new ResponseEntity<>(createTaskGroupMapper.mapTo(updated), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
@@ -2,7 +2,7 @@ package com.jonassavas.spring_task_api.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskGroupRequestDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskGroupDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskGroupWithTasksDto;
@@ -30,22 +30,25 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class TaskGroupController {
     private TaskGroupService taskGroupService;
 
-    private Mapper<TaskGroupEntity, CreateTaskGroupDto> createTaskGroupMapper;
+    private Mapper<TaskGroupEntity, TaskGroupRequestDto> taskGroupRequestMapper;
+    private Mapper<TaskGroupEntity, TaskGroupWithTasksDto> taskGroupWithTasksMapper;
     private Mapper<TaskGroupEntity, TaskGroupDto> taskGroupMapper;
 
     public TaskGroupController(TaskGroupService taskGroupService, 
-                                Mapper<TaskGroupEntity, CreateTaskGroupDto> createTaskGroupMapper,
-                                Mapper<TaskGroupEntity, TaskGroupDto> taskGroupMapper){
+                                Mapper<TaskGroupEntity, TaskGroupRequestDto> taskGroupRequestMapper,
+                                Mapper<TaskGroupEntity, TaskGroupDto> taskGroupMapper,
+                                Mapper<TaskGroupEntity, TaskGroupWithTasksDto> taskGroupWithTasksMapper){
         this.taskGroupService = taskGroupService;
-        this.createTaskGroupMapper = createTaskGroupMapper;
+        this.taskGroupRequestMapper = taskGroupRequestMapper;
         this.taskGroupMapper = taskGroupMapper;
+        this.taskGroupWithTasksMapper = taskGroupWithTasksMapper;
     }
 
     @PostMapping(path = "/taskgroups")
-    public ResponseEntity<CreateTaskGroupDto> createTaskGroup(@RequestBody CreateTaskGroupDto taskGroup) {
-        TaskGroupEntity taskGroupEntity = createTaskGroupMapper.mapFrom(taskGroup);
+    public ResponseEntity<TaskGroupRequestDto> createTaskGroup(@RequestBody TaskGroupRequestDto taskGroup) {
+        TaskGroupEntity taskGroupEntity = taskGroupRequestMapper.mapFrom(taskGroup);
         TaskGroupEntity savedTaskGroupEntity = taskGroupService.save(taskGroupEntity);
-        return new ResponseEntity<>(createTaskGroupMapper.mapTo(savedTaskGroupEntity), HttpStatus.CREATED);
+        return new ResponseEntity<>(taskGroupRequestMapper.mapTo(savedTaskGroupEntity), HttpStatus.CREATED);
     }
 
     @GetMapping("/taskgroups")
@@ -64,13 +67,13 @@ public class TaskGroupController {
     //         .toList();
     // }
 
-    // @GetMapping("/taskgroups/with-tasks")
-    //     public List<TaskGroupWithTasksDto> listTaskGroupsWithTasks() {
-    //         return taskGroupService.findAllWithTasks()
-    //             .stream()
-    //             .map(taskGroupWithTasksMapper::mapTo)
-    //             .toList();
-    //     }
+    @GetMapping("/taskgroups/with-tasks")
+        public List<TaskGroupWithTasksDto> listTaskGroupsWithTasks() {
+            return taskGroupService.findAllWithTasks()
+                .stream()
+                .map(taskGroupWithTasksMapper::mapTo)
+                .toList();
+    }
 
 
 
@@ -93,9 +96,9 @@ public class TaskGroupController {
     }
 
     @PatchMapping(path = "/taskgroups/{id}")
-    public ResponseEntity<CreateTaskGroupDto> updateTaskGroup(@PathVariable Long id, @RequestBody CreateTaskGroupDto dto){
+    public ResponseEntity<TaskGroupRequestDto> updateTaskGroup(@PathVariable Long id, @RequestBody TaskGroupRequestDto dto){
         TaskGroupEntity updated = taskGroupService.update(id, dto);
-        return new ResponseEntity<>(createTaskGroupMapper.mapTo(updated), HttpStatus.OK);
+        return new ResponseEntity<>(taskGroupRequestMapper.mapTo(updated), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
@@ -57,4 +57,10 @@ public class TaskGroupController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @DeleteMapping(path = "/taskgroups/{groupId}/tasks")
+    public ResponseEntity deleteAllTasks(@PathVariable("groupId") Long groupId){
+        taskGroupService.deleteAllTasks(groupId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
 }

--- a/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
+++ b/src/main/java/com/jonassavas/spring_task_api/controllers/TaskGroupController.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,6 +49,12 @@ public class TaskGroupController {
     public List<TaskGroupDto> listTaskGroups() {
         List<TaskGroupEntity> taskGroups = taskGroupService.findAll();
         return taskGroups.stream().map(taskGroupMapper::mapTo).collect(Collectors.toList());
+    }
+
+    @DeleteMapping(path = "/taskgroups/{id}")
+    public ResponseEntity deleteTaskGroup(@PathVariable("id") Long id){
+        taskGroupService.delete(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
 }

--- a/src/main/java/com/jonassavas/spring_task_api/domain/dto/CreateTaskDto.java
+++ b/src/main/java/com/jonassavas/spring_task_api/domain/dto/CreateTaskDto.java
@@ -1,5 +1,14 @@
 package com.jonassavas.spring_task_api.domain.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class CreateTaskDto {
-    
+    private String taskName;
 }

--- a/src/main/java/com/jonassavas/spring_task_api/domain/dto/CreateTaskDto.java
+++ b/src/main/java/com/jonassavas/spring_task_api/domain/dto/CreateTaskDto.java
@@ -10,5 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class CreateTaskDto {
+    private Long taskGroupId;
     private String taskName;
 }

--- a/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskGroupDto.java
+++ b/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskGroupDto.java
@@ -1,9 +1,5 @@
 package com.jonassavas.spring_task_api.domain.dto;
 
-import java.util.List;
-
-import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskGroupDto.java
+++ b/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskGroupDto.java
@@ -18,5 +18,4 @@ public class TaskGroupDto {
 
     private String taskGroupName;
 
-    private List<TaskEntity> tasks;
 }

--- a/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskGroupRequestDto.java
+++ b/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskGroupRequestDto.java
@@ -1,0 +1,25 @@
+package com.jonassavas.spring_task_api.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+
+/*
+    USED FOR:
+            - CREATE
+            - UPDATE
+
+    This class serves as the DTO for incoming and outgoing requests.
+    This means that when the user wants to create/change any parameter
+    of their TaskGroup they do it via this DTO.
+*/
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TaskGroupRequestDto {
+    private String taskGroupName;
+}

--- a/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskGroupWithTasksDto.java
+++ b/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskGroupWithTasksDto.java
@@ -1,5 +1,9 @@
 package com.jonassavas.spring_task_api.domain.dto;
 
+import java.util.List;
+
+import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,10 +13,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class CreateTaskGroupDto {
+public class TaskGroupWithTasksDto {
     private Long id;
 
     private String taskGroupName;
 
-    //private List<TaskEntity> tasks; //We don't allow tasks on create
+    private List<TaskDto> tasks;
 }

--- a/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskRequestDto.java
+++ b/src/main/java/com/jonassavas/spring_task_api/domain/dto/TaskRequestDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class CreateTaskDto {
+public class TaskRequestDto {
     private Long taskGroupId;
     private String taskName;
 }

--- a/src/main/java/com/jonassavas/spring_task_api/mappers/impl/CreateTaskMapper.java
+++ b/src/main/java/com/jonassavas/spring_task_api/mappers/impl/CreateTaskMapper.java
@@ -1,0 +1,36 @@
+package com.jonassavas.spring_task_api.mappers.impl;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskDto;
+import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
+import com.jonassavas.spring_task_api.mappers.Mapper;
+
+@Component
+public class CreateTaskMapper implements Mapper<TaskEntity, CreateTaskDto> {
+
+    private ModelMapper modelMapper;
+
+    public CreateTaskMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+
+        // Skip taskGroup when mapping DTO -> Entity
+        this.modelMapper.typeMap(CreateTaskDto.class, TaskEntity.class)
+                .addMappings(mapper -> mapper.skip(TaskEntity::setTaskGroup));
+    }
+
+    @Override
+    public CreateTaskDto mapTo(TaskEntity taskEntity) {
+        CreateTaskDto dto = modelMapper.map(taskEntity, CreateTaskDto.class);
+        //dto.setTaskGroupId(taskEntity.getTaskGroup().getId());
+        return dto;
+    }
+
+    @Override
+    public TaskEntity mapFrom(CreateTaskDto createTaskDto) {
+        return modelMapper.map(createTaskDto, TaskEntity.class);
+    }
+}
+

--- a/src/main/java/com/jonassavas/spring_task_api/mappers/impl/TaskGroupRequestMapper.java
+++ b/src/main/java/com/jonassavas/spring_task_api/mappers/impl/TaskGroupRequestMapper.java
@@ -4,25 +4,25 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
 
 
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskGroupRequestDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.mappers.Mapper;
 
 @Component
-public class CreateTaskGroupMapper implements Mapper<TaskGroupEntity, CreateTaskGroupDto>{
+public class TaskGroupRequestMapper implements Mapper<TaskGroupEntity, TaskGroupRequestDto>{
     private ModelMapper modelMapper;
 
-    public CreateTaskGroupMapper(ModelMapper modelMapper){
+    public TaskGroupRequestMapper(ModelMapper modelMapper){
         this.modelMapper = modelMapper;
     }
     
     @Override
-    public CreateTaskGroupDto mapTo(TaskGroupEntity taskGroupEntity){
-        return modelMapper.map(taskGroupEntity, CreateTaskGroupDto.class);
+    public TaskGroupRequestDto mapTo(TaskGroupEntity taskGroupEntity){
+        return modelMapper.map(taskGroupEntity, TaskGroupRequestDto.class);
     }
 
     @Override
-    public TaskGroupEntity mapFrom(CreateTaskGroupDto taskGroupDto){
+    public TaskGroupEntity mapFrom(TaskGroupRequestDto taskGroupDto){
         return modelMapper.map(taskGroupDto, TaskGroupEntity.class);
     }
 }

--- a/src/main/java/com/jonassavas/spring_task_api/mappers/impl/TaskGroupWithTasksMapper.java
+++ b/src/main/java/com/jonassavas/spring_task_api/mappers/impl/TaskGroupWithTasksMapper.java
@@ -1,0 +1,28 @@
+package com.jonassavas.spring_task_api.mappers.impl;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+
+import com.jonassavas.spring_task_api.domain.dto.TaskGroupWithTasksDto;
+import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
+import com.jonassavas.spring_task_api.mappers.Mapper;
+
+@Component
+public class TaskGroupWithTasksMapper implements Mapper<TaskGroupEntity, TaskGroupWithTasksDto>{
+    private ModelMapper modelMapper;
+
+    public TaskGroupWithTasksMapper(ModelMapper modelMapper){
+        this.modelMapper = modelMapper;
+    }
+    
+    @Override
+    public TaskGroupWithTasksDto mapTo(TaskGroupEntity taskGroupEntity){
+        return modelMapper.map(taskGroupEntity, TaskGroupWithTasksDto.class);
+    }
+
+    @Override
+    public TaskGroupEntity mapFrom(TaskGroupWithTasksDto taskGroupDto){
+        return modelMapper.map(taskGroupDto, TaskGroupEntity.class);
+    }
+}

--- a/src/main/java/com/jonassavas/spring_task_api/mappers/impl/TaskRequestMapper.java
+++ b/src/main/java/com/jonassavas/spring_task_api/mappers/impl/TaskRequestMapper.java
@@ -3,33 +3,33 @@ package com.jonassavas.spring_task_api.mappers.impl;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
 
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskRequestDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.mappers.Mapper;
 
 @Component
-public class CreateTaskMapper implements Mapper<TaskEntity, CreateTaskDto> {
+public class TaskRequestMapper implements Mapper<TaskEntity, TaskRequestDto> {
 
     private ModelMapper modelMapper;
 
-    public CreateTaskMapper(ModelMapper modelMapper) {
+    public TaskRequestMapper(ModelMapper modelMapper) {
         this.modelMapper = modelMapper;
 
         // Skip taskGroup when mapping DTO -> Entity
-        this.modelMapper.typeMap(CreateTaskDto.class, TaskEntity.class)
+        this.modelMapper.typeMap(TaskRequestDto.class, TaskEntity.class)
                 .addMappings(mapper -> mapper.skip(TaskEntity::setTaskGroup));
     }
 
     @Override
-    public CreateTaskDto mapTo(TaskEntity taskEntity) {
-        CreateTaskDto dto = modelMapper.map(taskEntity, CreateTaskDto.class);
+    public TaskRequestDto mapTo(TaskEntity taskEntity) {
+        TaskRequestDto dto = modelMapper.map(taskEntity, TaskRequestDto.class);
         //dto.setTaskGroupId(taskEntity.getTaskGroup().getId());
         return dto;
     }
 
     @Override
-    public TaskEntity mapFrom(CreateTaskDto createTaskDto) {
+    public TaskEntity mapFrom(TaskRequestDto createTaskDto) {
         return modelMapper.map(createTaskDto, TaskEntity.class);
     }
 }

--- a/src/main/java/com/jonassavas/spring_task_api/repositories/TaskGroupRepository.java
+++ b/src/main/java/com/jonassavas/spring_task_api/repositories/TaskGroupRepository.java
@@ -1,5 +1,9 @@
 package com.jonassavas.spring_task_api.repositories;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +16,16 @@ retrieval, update, delete, and search operation on objects.*/
 @Repository 
 public interface TaskGroupRepository extends CrudRepository<TaskGroupEntity, Long>{
     
+    @Query("""
+        SELECT tg FROM TaskGroupEntity tg
+        LEFT JOIN FETCH tg.tasks            
+    """) 
+    List<TaskGroupEntity> findAllWithTasks();
+
+    @Query("""
+        SELECT tg from TaskGroupEntity tg
+        LEFT JOIN FETCH tg.tasks
+        WHERE tg.id = :id
+    """)
+    Optional<TaskGroupEntity> findByIdWithTasks(Long id);
 }

--- a/src/main/java/com/jonassavas/spring_task_api/repositories/TaskGroupRepository.java
+++ b/src/main/java/com/jonassavas/spring_task_api/repositories/TaskGroupRepository.java
@@ -3,6 +3,7 @@ package com.jonassavas.spring_task_api.repositories;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
@@ -14,7 +15,7 @@ import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 which is used to indicate that the class provides the mechanism for storage, 
 retrieval, update, delete, and search operation on objects.*/
 @Repository 
-public interface TaskGroupRepository extends CrudRepository<TaskGroupEntity, Long>{
+public interface TaskGroupRepository extends JpaRepository<TaskGroupEntity, Long>{
     
     @Query("""
         SELECT tg FROM TaskGroupEntity tg

--- a/src/main/java/com/jonassavas/spring_task_api/repositories/TaskRepository.java
+++ b/src/main/java/com/jonassavas/spring_task_api/repositories/TaskRepository.java
@@ -1,5 +1,6 @@
 package com.jonassavas.spring_task_api.repositories;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +11,6 @@ import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 which is used to indicate that the class provides the mechanism for storage, 
 retrieval, update, delete, and search operation on objects.*/
 @Repository 
-public interface TaskRepository extends CrudRepository<TaskEntity, Long> {
+public interface TaskRepository extends JpaRepository<TaskEntity, Long> {
     
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/TaskGroupService.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/TaskGroupService.java
@@ -10,4 +10,6 @@ public interface TaskGroupService {
     List<TaskGroupEntity> findAll();
 
     boolean isExist(Long id);
+
+    void delete(Long id);
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/TaskGroupService.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/TaskGroupService.java
@@ -2,6 +2,7 @@ package com.jonassavas.spring_task_api.services;
 
 import java.util.List;
 
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 
 public interface TaskGroupService {
@@ -12,4 +13,8 @@ public interface TaskGroupService {
     boolean isExist(Long id);
 
     void delete(Long id);
+
+    void deleteAllTasks(Long id);
+
+    TaskGroupEntity update(Long id, CreateTaskGroupDto dto);
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/TaskGroupService.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/TaskGroupService.java
@@ -2,7 +2,7 @@ package com.jonassavas.spring_task_api.services;
 
 import java.util.List;
 
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskGroupRequestDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 
 public interface TaskGroupService {
@@ -10,11 +10,15 @@ public interface TaskGroupService {
 
     List<TaskGroupEntity> findAll();
 
+    List<TaskGroupEntity> findAllWithTasks();
+
+    TaskGroupEntity findByIdWithTasks(Long id);
+
     boolean isExist(Long id);
 
     void delete(Long id);
 
     void deleteAllTasks(Long id);
 
-    TaskGroupEntity update(Long id, CreateTaskGroupDto dto);
+    TaskGroupEntity update(Long id, TaskGroupRequestDto dto);
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/TaskGroupService.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/TaskGroupService.java
@@ -8,4 +8,6 @@ public interface TaskGroupService {
     TaskGroupEntity save(TaskGroupEntity taskGroupEntity);
 
     List<TaskGroupEntity> findAll();
+
+    boolean isExist(Long id);
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/TaskService.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/TaskService.java
@@ -1,11 +1,17 @@
 package com.jonassavas.spring_task_api.services;
 
+import java.util.List;
+
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 
 public interface TaskService {
     TaskEntity createTask(Long groupId, TaskEntity taskEntity);
 
-    void deleteTask(Long id);
+    void delete(Long id);
 
     boolean isExist(Long id);
+
+    //TaskEntity update(TaskEntity taskEntity);
+
+    List<TaskEntity> findAll();
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/TaskService.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/TaskService.java
@@ -2,7 +2,7 @@ package com.jonassavas.spring_task_api.services;
 
 import java.util.List;
 
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskRequestDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 
 public interface TaskService {
@@ -12,7 +12,7 @@ public interface TaskService {
 
     boolean isExist(Long id);
 
-    TaskEntity update(Long id, CreateTaskDto dto);
+    TaskEntity update(Long id, TaskRequestDto dto);
 
     List<TaskEntity> findAll();
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/TaskService.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/TaskService.java
@@ -6,4 +6,6 @@ public interface TaskService {
     TaskEntity createTask(Long groupId, TaskEntity taskEntity);
 
     void deleteTask(Long id);
+
+    boolean isExist(Long id);
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/TaskService.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/TaskService.java
@@ -2,6 +2,7 @@ package com.jonassavas.spring_task_api.services;
 
 import java.util.List;
 
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 
 public interface TaskService {
@@ -11,7 +12,7 @@ public interface TaskService {
 
     boolean isExist(Long id);
 
-    //TaskEntity update(TaskEntity taskEntity);
+    TaskEntity update(Long id, CreateTaskDto dto);
 
     List<TaskEntity> findAll();
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
@@ -10,6 +10,7 @@ import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.repositories.TaskGroupRepository;
 import com.jonassavas.spring_task_api.services.TaskGroupService;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 
 @Service
@@ -43,5 +44,15 @@ public class TaskGroupServiceImpl implements TaskGroupService{
     @Override
     public void delete(Long id){
         taskGroupRepository.deleteById(id);
+    }
+
+    @Transactional
+    @Override
+    public void deleteAllTasks(Long id){
+        TaskGroupEntity taskGroup = taskGroupRepository.findById(id)
+                                    .orElseThrow(() -> new EntityNotFoundException(
+                                        "TaskGroup not found with id " + id));
+
+        taskGroup.getTasks().clear();
     }
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
@@ -6,7 +6,7 @@ import java.util.stream.StreamSupport;
 
 import org.springframework.stereotype.Service;
 
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskGroupRequestDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.repositories.TaskGroupRepository;
 import com.jonassavas.spring_task_api.services.TaskGroupService;
@@ -37,6 +37,18 @@ public class TaskGroupServiceImpl implements TaskGroupService{
     }
 
     @Override
+    public List<TaskGroupEntity> findAllWithTasks(){
+        return taskGroupRepository.findAllWithTasks();
+    }
+
+    @Override
+    public TaskGroupEntity findByIdWithTasks(Long id){
+        return taskGroupRepository.findByIdWithTasks(id)
+            .orElseThrow(() -> new EntityNotFoundException(
+                "TaskGroup not found with id " + id));
+    }
+
+    @Override
     public boolean isExist(Long id){
         return taskGroupRepository.existsById(id);
     }
@@ -59,7 +71,7 @@ public class TaskGroupServiceImpl implements TaskGroupService{
 
     @Transactional
     @Override
-    public TaskGroupEntity update(Long id, CreateTaskGroupDto dto){
+    public TaskGroupEntity update(Long id, TaskGroupRequestDto dto){
         TaskGroupEntity taskGroup = taskGroupRepository.findById(id)
                     .orElseThrow(() -> new EntityNotFoundException(
                                         "TaskGroup not found with it: " + id));

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
@@ -15,6 +15,7 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 
 @Service
+@Transactional
 public class TaskGroupServiceImpl implements TaskGroupService{
     
     private TaskGroupRepository taskGroupRepository;
@@ -53,13 +54,11 @@ public class TaskGroupServiceImpl implements TaskGroupService{
         return taskGroupRepository.existsById(id);
     }
 
-    @Transactional
     @Override
     public void delete(Long id){
         taskGroupRepository.deleteById(id);
     }
-
-    @Transactional
+ 
     @Override
     public void deleteAllTasks(Long id){
         TaskGroupEntity taskGroup = taskGroupRepository.findById(id)
@@ -69,7 +68,6 @@ public class TaskGroupServiceImpl implements TaskGroupService{
         taskGroup.getTasks().clear();
     }
 
-    @Transactional
     @Override
     public TaskGroupEntity update(Long id, TaskGroupRequestDto dto){
         TaskGroupEntity taskGroup = taskGroupRepository.findById(id)

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.stream.StreamSupport;
 
 import org.springframework.stereotype.Service;
 
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.repositories.TaskGroupRepository;
 import com.jonassavas.spring_task_api.services.TaskGroupService;
@@ -54,5 +55,19 @@ public class TaskGroupServiceImpl implements TaskGroupService{
                                         "TaskGroup not found with id " + id));
 
         taskGroup.getTasks().clear();
+    }
+
+    @Transactional
+    @Override
+    public TaskGroupEntity update(Long id, CreateTaskGroupDto dto){
+        TaskGroupEntity taskGroup = taskGroupRepository.findById(id)
+                    .orElseThrow(() -> new EntityNotFoundException(
+                                        "TaskGroup not found with it: " + id));
+    
+        if(dto.getTaskGroupName() != null){
+            taskGroup.setTaskGroupName(dto.getTaskGroupName());
+        }
+
+        return taskGroup;
     }
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
@@ -10,6 +10,8 @@ import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.repositories.TaskGroupRepository;
 import com.jonassavas.spring_task_api.services.TaskGroupService;
 
+import jakarta.transaction.Transactional;
+
 @Service
 public class TaskGroupServiceImpl implements TaskGroupService{
     
@@ -35,5 +37,11 @@ public class TaskGroupServiceImpl implements TaskGroupService{
     @Override
     public boolean isExist(Long id){
         return taskGroupRepository.existsById(id);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Long id){
+        taskGroupRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskGroupServiceImpl.java
@@ -31,4 +31,9 @@ public class TaskGroupServiceImpl implements TaskGroupService{
                                     .spliterator(), false)
                                     .collect(Collectors.toList());
     }
+
+    @Override
+    public boolean isExist(Long id){
+        return taskGroupRepository.existsById(id);
+    }
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
@@ -17,6 +17,7 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 
 @Service
+@Transactional
 public class TaskServiceImpl implements TaskService{
     private final TaskRepository taskRepository;
     private final TaskGroupRepository taskGroupRepository;
@@ -65,7 +66,6 @@ public class TaskServiceImpl implements TaskService{
 
 
     @Override
-    @Transactional
     public TaskEntity update(Long id, CreateTaskDto dto){
         TaskEntity task = taskRepository.findById(id)
                             .orElseThrow(() -> new EntityNotFoundException(

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
@@ -6,7 +6,7 @@ import java.util.stream.StreamSupport;
 
 import org.springframework.stereotype.Service;
 
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskRequestDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.repositories.TaskGroupRepository;
@@ -66,7 +66,7 @@ public class TaskServiceImpl implements TaskService{
 
 
     @Override
-    public TaskEntity update(Long id, CreateTaskDto dto){
+    public TaskEntity update(Long id, TaskRequestDto dto){
         TaskEntity task = taskRepository.findById(id)
                             .orElseThrow(() -> new EntityNotFoundException(
                                 "Task not found with id " + id));

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
@@ -1,5 +1,9 @@
 package com.jonassavas.spring_task_api.services.impl;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 import org.springframework.stereotype.Service;
 
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
@@ -33,7 +37,7 @@ public class TaskServiceImpl implements TaskService{
     }
 
     @Override
-    public void deleteTask(Long id){
+    public void delete(Long id){
         TaskEntity task = taskRepository.findById(id)
             .orElseThrow(() -> new EntityNotFoundException("Task not found with id " + id));
 
@@ -47,6 +51,14 @@ public class TaskServiceImpl implements TaskService{
     @Override
     public boolean isExist(Long id){
         return taskRepository.existsById(id);
+    }
+
+    @Override
+    public List<TaskEntity> findAll(){
+        return StreamSupport.stream(taskRepository
+                                    .findAll()
+                                    .spliterator(), false)
+                                    .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.stream.StreamSupport;
 
 import org.springframework.stereotype.Service;
 
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.repositories.TaskGroupRepository;
@@ -59,6 +60,12 @@ public class TaskServiceImpl implements TaskService{
                                     .findAll()
                                     .spliterator(), false)
                                     .collect(Collectors.toList());
+    }
+
+    // TODO
+    @Override
+    public TaskEntity update(Long id, CreateTaskDto dto){
+        return null;
     }
 
 }

--- a/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
+++ b/src/main/java/com/jonassavas/spring_task_api/services/impl/TaskServiceImpl.java
@@ -29,9 +29,7 @@ public class TaskServiceImpl implements TaskService{
 
         taskGroup.addTask(taskEntity); // Cascade saves task automatically
 
-        taskRepository.save(taskEntity);
-
-        return taskEntity;
+        return taskRepository.save(taskEntity);
     }
 
     @Override
@@ -42,6 +40,13 @@ public class TaskServiceImpl implements TaskService{
         TaskGroupEntity group = task.getTaskGroup();
 
         group.removeTask(task); // Triggers orphanRemoval
+
+        taskRepository.delete(task);
+    }
+
+    @Override
+    public boolean isExist(Long id){
+        return taskRepository.existsById(id);
     }
 
 }

--- a/src/test/java/com/jonassavas/spring_task_api/TestDataUtil.java
+++ b/src/test/java/com/jonassavas/spring_task_api/TestDataUtil.java
@@ -1,11 +1,18 @@
 package com.jonassavas.spring_task_api;
 
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
 import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 
 public class TestDataUtil {
+
+    public static CreateTaskDto createTestCreateTaskDto(){
+        return CreateTaskDto.builder()
+                            .taskName("Create Task Dto")
+                            .build();
+    }
 
     public static TaskDto createTestTaskDtoA(){
         return TaskDto.builder()

--- a/src/test/java/com/jonassavas/spring_task_api/TestDataUtil.java
+++ b/src/test/java/com/jonassavas/spring_task_api/TestDataUtil.java
@@ -1,7 +1,7 @@
 package com.jonassavas.spring_task_api;
 
 import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskGroupRequestDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
@@ -60,20 +60,20 @@ public class TestDataUtil {
                                 .build();
     }
 
-    public static CreateTaskGroupDto createTaskGroupDtoA(){
-        return CreateTaskGroupDto.builder()
+    public static TaskGroupRequestDto createTaskGroupDtoA(){
+        return TaskGroupRequestDto.builder()
                                 .taskGroupName("Task Group A")
                                 .build();
     }
 
-    public static CreateTaskGroupDto createTaskGroupDtoB(){
-        return CreateTaskGroupDto.builder()
+    public static TaskGroupRequestDto createTaskGroupDtoB(){
+        return TaskGroupRequestDto.builder()
                                 .taskGroupName("Task Group B")
                                 .build();
     }
 
-    public static CreateTaskGroupDto createTaskGroupDtoC(){
-        return CreateTaskGroupDto.builder()
+    public static TaskGroupRequestDto createTaskGroupDtoC(){
+        return TaskGroupRequestDto.builder()
                                 .taskGroupName("Task Group C")
                                 .build();
     }

--- a/src/test/java/com/jonassavas/spring_task_api/TestDataUtil.java
+++ b/src/test/java/com/jonassavas/spring_task_api/TestDataUtil.java
@@ -1,6 +1,6 @@
 package com.jonassavas.spring_task_api;
 
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskRequestDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskGroupRequestDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
@@ -8,8 +8,8 @@ import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 
 public class TestDataUtil {
 
-    public static CreateTaskDto createTestCreateTaskDto(){
-        return CreateTaskDto.builder()
+    public static TaskRequestDto createTestCreateTaskDto(){
+        return TaskRequestDto.builder()
                             .taskName("Create Task Dto")
                             .build();
     }

--- a/src/test/java/com/jonassavas/spring_task_api/TestDataUtil.java
+++ b/src/test/java/com/jonassavas/spring_task_api/TestDataUtil.java
@@ -1,5 +1,6 @@
 package com.jonassavas.spring_task_api;
 
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
@@ -48,6 +49,24 @@ public class TestDataUtil {
 
     public static TaskGroupEntity createTaskGroupEntityC(){
         return TaskGroupEntity.builder()
+                                .taskGroupName("Task Group C")
+                                .build();
+    }
+
+    public static CreateTaskGroupDto createTaskGroupDtoA(){
+        return CreateTaskGroupDto.builder()
+                                .taskGroupName("Task Group A")
+                                .build();
+    }
+
+    public static CreateTaskGroupDto createTaskGroupDtoB(){
+        return CreateTaskGroupDto.builder()
+                                .taskGroupName("Task Group B")
+                                .build();
+    }
+
+    public static CreateTaskGroupDto createTaskGroupDtoC(){
+        return CreateTaskGroupDto.builder()
                                 .taskGroupName("Task Group C")
                                 .build();
     }

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jonassavas.spring_task_api.TestDataUtil;
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
@@ -160,5 +161,90 @@ public class TaskControllerIntegrationTests {
         
     }
 
+    // TODO
+    // - Update task: Task name, task group, & both
 
+    @Test
+    @Transactional
+    public void testUpdateTaskName() throws Exception{
+        TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
+        taskGroupService.save(testTaskGroupEntityA);
+
+        TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
+        taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
+
+        CreateTaskDto testCreateTaskDto = TestDataUtil.createTestCreateTaskDto();
+        testCreateTaskDto.setTaskName("UPDATED");
+
+        String taskJson = objectMapper.writeValueAsString(testCreateTaskDto);
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.patch("/tasks/" + testTaskEntityA.getId())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(taskJson)
+        ).andExpect(
+            MockMvcResultMatchers.status().isOk()
+        ).andExpect(
+            MockMvcResultMatchers.jsonPath("$.taskName").value("UPDATED")
+        );
+    }
+
+    @Test
+    @Transactional
+    public void testUpdateTaskGroupId() throws Exception{
+        TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
+        taskGroupService.save(testTaskGroupEntityA);
+
+        TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
+        taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
+
+        TaskGroupEntity testTaskGroupEntityB = TestDataUtil.createTaskGroupEntityB();
+        taskGroupService.save(testTaskGroupEntityB);
+
+        CreateTaskDto testCreateTaskDto = TestDataUtil.createTestCreateTaskDto();
+        testCreateTaskDto.setTaskGroupId(testTaskGroupEntityB.getId());
+
+        String taskJson = objectMapper.writeValueAsString(testCreateTaskDto);
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.patch("/tasks/" + testTaskEntityA.getId())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(taskJson)
+        ).andExpect(
+            MockMvcResultMatchers.status().isOk()
+        ).andExpect(
+            MockMvcResultMatchers.jsonPath("$.taskGroupId").value(testTaskGroupEntityB.getId())
+        );
+    }
+
+    @Test
+    @Transactional
+    public void testUpdateBothTaskGroupIdAndTaskName() throws Exception{
+        TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
+        taskGroupService.save(testTaskGroupEntityA);
+
+        TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
+        taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
+
+        TaskGroupEntity testTaskGroupEntityB = TestDataUtil.createTaskGroupEntityB();
+        taskGroupService.save(testTaskGroupEntityB);
+
+        CreateTaskDto testCreateTaskDto = TestDataUtil.createTestCreateTaskDto();
+        testCreateTaskDto.setTaskGroupId(testTaskGroupEntityB.getId());
+        testCreateTaskDto.setTaskName("UPDATED");
+
+        String taskJson = objectMapper.writeValueAsString(testCreateTaskDto);
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.patch("/tasks/" + testTaskEntityA.getId())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(taskJson)
+        ).andExpect(
+            MockMvcResultMatchers.status().isOk()
+        ).andExpect(
+            MockMvcResultMatchers.jsonPath("$.taskGroupId").value(testTaskGroupEntityB.getId())
+        ).andExpect(
+            MockMvcResultMatchers.jsonPath("$.taskName").value("UPDATED")
+        );
+    }
 }

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
@@ -16,7 +16,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jonassavas.spring_task_api.TestDataUtil;
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskRequestDto;
 import com.jonassavas.spring_task_api.domain.dto.TaskDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
@@ -178,7 +178,7 @@ public class TaskControllerIntegrationTests {
         TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
         taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
 
-        CreateTaskDto testCreateTaskDto = TestDataUtil.createTestCreateTaskDto();
+        TaskRequestDto testCreateTaskDto = TestDataUtil.createTestCreateTaskDto();
         testCreateTaskDto.setTaskName("UPDATED");
 
         String taskJson = objectMapper.writeValueAsString(testCreateTaskDto);
@@ -205,7 +205,7 @@ public class TaskControllerIntegrationTests {
         TaskGroupEntity testTaskGroupEntityB = TestDataUtil.createTaskGroupEntityB();
         taskGroupService.save(testTaskGroupEntityB);
 
-        CreateTaskDto testCreateTaskDto = TestDataUtil.createTestCreateTaskDto();
+        TaskRequestDto testCreateTaskDto = TestDataUtil.createTestCreateTaskDto();
         testCreateTaskDto.setTaskGroupId(testTaskGroupEntityB.getId());
 
         String taskJson = objectMapper.writeValueAsString(testCreateTaskDto);
@@ -232,7 +232,7 @@ public class TaskControllerIntegrationTests {
         TaskGroupEntity testTaskGroupEntityB = TestDataUtil.createTaskGroupEntityB();
         taskGroupService.save(testTaskGroupEntityB);
 
-        CreateTaskDto testCreateTaskDto = TestDataUtil.createTestCreateTaskDto();
+        TaskRequestDto testCreateTaskDto = TestDataUtil.createTestCreateTaskDto();
         testCreateTaskDto.setTaskGroupId(testTaskGroupEntityB.getId());
         testCreateTaskDto.setTaskName("UPDATED");
 

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
@@ -23,7 +23,6 @@ import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.services.TaskGroupService;
 import com.jonassavas.spring_task_api.services.TaskService;
 
-import jakarta.transaction.Transactional;
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -113,7 +112,6 @@ public class TaskControllerIntegrationTests {
 
 
     @Test
-    @Transactional
     public void testThatDeleteTaskReturnsHttp204() throws Exception{
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
         taskGroupService.save(testTaskGroupEntityA);
@@ -121,7 +119,10 @@ public class TaskControllerIntegrationTests {
         TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
         taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
 
-        assertThat(testTaskGroupEntityA.getTasks().size()).isEqualTo(1); 
+        assertThat(taskGroupService
+                    .findByIdWithTasks(testTaskGroupEntityA.getId())
+                        .getTasks().size())
+                .isEqualTo(1); 
 
         mockMvc.perform(
             MockMvcRequestBuilders.delete("/tasks/" + testTaskEntityA.getId())
@@ -129,11 +130,13 @@ public class TaskControllerIntegrationTests {
         ).andExpect(
             MockMvcResultMatchers.status().isNoContent());
 
-        assertThat(testTaskGroupEntityA.getTasks().size()).isEqualTo(0); 
+        assertThat(taskGroupService
+                    .findByIdWithTasks(testTaskGroupEntityA.getId())
+                        .getTasks().size())
+                .isEqualTo(0); 
     }
 
     @Test
-    @Transactional
     public void testThatDeleteTaskDeletesCorrectTask() throws Exception{
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
         taskGroupService.save(testTaskGroupEntityA);
@@ -144,17 +147,22 @@ public class TaskControllerIntegrationTests {
         TaskEntity testTaskEntityB = TestDataUtil.createTestTaskEntityB();
         taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityB);
 
-        assertThat(testTaskGroupEntityA.getTasks().size()).isEqualTo(2);
+        assertThat(taskGroupService
+                    .findByIdWithTasks(testTaskGroupEntityA.getId())
+                        .getTasks().size())
+                .isEqualTo(2); 
 
         mockMvc.perform(
             MockMvcRequestBuilders.delete("/tasks/" + testTaskEntityA.getId())
             .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(
             MockMvcResultMatchers.status().isNoContent());
-
-        assertThat(testTaskGroupEntityA.getTasks().size()).isEqualTo(1);
         
-        List<TaskEntity> result = testTaskGroupEntityA.getTasks();
+        List<TaskEntity> result = taskGroupService
+                                    .findByIdWithTasks(testTaskGroupEntityA.getId())
+                                        .getTasks();
+
+        assertThat(result.size()).isEqualTo(1);
         assertThat(result)
                 .extracting(TaskEntity::getId)
                 .containsExactly(testTaskEntityB.getId());
@@ -163,7 +171,6 @@ public class TaskControllerIntegrationTests {
 
 
     @Test
-    @Transactional
     public void testUpdateTaskName() throws Exception{
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
         taskGroupService.save(testTaskGroupEntityA);
@@ -188,7 +195,6 @@ public class TaskControllerIntegrationTests {
     }
 
     @Test
-    @Transactional
     public void testUpdateTaskGroupId() throws Exception{
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
         taskGroupService.save(testTaskGroupEntityA);
@@ -216,7 +222,6 @@ public class TaskControllerIntegrationTests {
     }
 
     @Test
-    @Transactional
     public void testUpdateBothTaskGroupIdAndTaskName() throws Exception{
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
         taskGroupService.save(testTaskGroupEntityA);

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
@@ -1,5 +1,9 @@
 package com.jonassavas.spring_task_api.controllers;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,7 +22,7 @@ import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.services.TaskGroupService;
 import com.jonassavas.spring_task_api.services.TaskService;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import jakarta.transaction.Transactional;
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -107,24 +111,53 @@ public class TaskControllerIntegrationTests {
     }
 
 
-    // TODO
     @Test
+    @Transactional
     public void testThatDeleteTaskReturnsHttp204() throws Exception{
-        // TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
-        // taskGroupService.save(testTaskGroupEntityA);
+        TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
+        taskGroupService.save(testTaskGroupEntityA);
 
-        // TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
-        // taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
+        TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
+        taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
 
-        // assertThat(testTaskGroupEntityA.getTasks()).hasSize(1);
+        assertThat(testTaskGroupEntityA.getTasks().size()).isEqualTo(1); 
 
-        // mockMvc.perform(
-        //     MockMvcRequestBuilders.delete("/tasks/" + testTaskEntityA.getId())
-        //     .contentType(MediaType.APPLICATION_JSON)
-        // ).andExpect(
-        //     MockMvcResultMatchers.status().isNoContent());
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/tasks/" + testTaskEntityA.getId())
+            .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(
+            MockMvcResultMatchers.status().isNoContent());
 
-        // assertThat(testTaskGroupEntityA.getTasks()).isEmpty();
+        assertThat(testTaskGroupEntityA.getTasks().size()).isEqualTo(0); 
+    }
+
+    @Test
+    @Transactional
+    public void testThatDeleteTaskDeletesCorrectTask() throws Exception{
+        TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
+        taskGroupService.save(testTaskGroupEntityA);
+
+        TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
+        taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
+
+        TaskEntity testTaskEntityB = TestDataUtil.createTestTaskEntityB();
+        taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityB);
+
+        assertThat(testTaskGroupEntityA.getTasks().size()).isEqualTo(2);
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/tasks/" + testTaskEntityA.getId())
+            .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(
+            MockMvcResultMatchers.status().isNoContent());
+
+        assertThat(testTaskGroupEntityA.getTasks().size()).isEqualTo(1);
+        
+        List<TaskEntity> result = testTaskGroupEntityA.getTasks();
+        assertThat(result)
+                .extracting(TaskEntity::getId)
+                .containsExactly(testTaskEntityB.getId());
+        
     }
 
 

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
@@ -86,30 +86,26 @@ public class TaskControllerIntegrationTests {
         );
     }
     
-    // TODO
     @Test
     public void testThatCreateTaskWithoutValidTaskGroupReturns404() throws Exception{
         // TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
         // taskGroupService.save(testTaskGroupEntityA);
 
-        // TaskDto testTaskDtoA = TestDataUtil.createTestTaskDtoA();
+        TaskDto testTaskDtoA = TestDataUtil.createTestTaskDtoA();
 
-        // testTaskDtoA.setTaskGroupId(testTaskGroupEntityA.getId());
+        testTaskDtoA.setTaskGroupId(99L);
 
-        // String taskJson = objectMapper.writeValueAsString(testTaskDtoA);
+        String taskJson = objectMapper.writeValueAsString(testTaskDtoA);
 
-        // mockMvc.perform(
-        //     MockMvcRequestBuilders.post("/taskgroups/" + testTaskGroupEntityA.getId() + "/tasks")
-        //     .contentType(MediaType.APPLICATION_JSON)
-        //     .content(taskJson)
-        // ).andExpect(
-        //     MockMvcResultMatchers.jsonPath("$.taskGroupId").isNumber()
-        // ).andExpect(
-        //     MockMvcResultMatchers.jsonPath("$.id").isNumber()
-        // ).andExpect( 
-        //     MockMvcResultMatchers.jsonPath("$.taskName").value("Task A")
-        // );
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/taskgroups/" + 99 + "/tasks")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(taskJson)
+        ).andExpect(
+            MockMvcResultMatchers.status().isNotFound()
+        );
     }
+
 
     // TODO
     @Test

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskControllerIntegrationTests.java
@@ -161,8 +161,6 @@ public class TaskControllerIntegrationTests {
         
     }
 
-    // TODO
-    // - Update task: Task name, task group, & both
 
     @Test
     @Transactional

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
@@ -16,6 +16,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jonassavas.spring_task_api.TestDataUtil;
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
+import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.services.TaskGroupService;
@@ -232,5 +234,26 @@ public class TaskGroupControllerIntegrationTests {
                                     .extracting(TaskEntity::getId)
                                     .containsExactly(testTaskEntityB.getId(),
                                                      testTaskEntityC.getId());
+    }
+
+
+    @Test
+    public void testThatUpdateTaskGroupReturnsHttp200() throws Exception{
+        TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
+        taskGroupService.save(testTaskGroupEntityA);
+
+        CreateTaskGroupDto testTaskGroupDtoA = TestDataUtil.createTaskGroupDtoA();
+        testTaskGroupDtoA.setTaskGroupName("UPDATED");
+        String taskGroupJson = objectMapper.writeValueAsString(testTaskGroupDtoA);
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.patch("/taskgroups/" + testTaskGroupEntityA.getId())
+                .contentType(MediaType.APPLICATION_JSON)   
+                .content(taskGroupJson) 
+        ).andExpect(
+            MockMvcResultMatchers.status().isOk()
+        ).andExpect(
+            MockMvcResultMatchers.jsonPath("$.taskGroupName").value("UPDATED")
+        );
     }
 }

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
@@ -256,4 +256,9 @@ public class TaskGroupControllerIntegrationTests {
             MockMvcResultMatchers.jsonPath("$.taskGroupName").value("UPDATED")
         );
     }
+
+    // TODO 
+    // - Update task group name etc
+    // - DELETE all tasks
+    // - 
 }

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
@@ -261,4 +261,31 @@ public class TaskGroupControllerIntegrationTests {
     // - Update task group name etc
     // - DELETE all tasks
     // - 
+
+    @Test
+    //@Transactional
+    public void testThatDeleteAllTasksDeletesCorrespondingTasks() throws Exception{
+        TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
+        taskGroupService.save(testTaskGroupEntityA);
+        TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
+        taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
+        TaskEntity testTaskEntityB = TestDataUtil.createTestTaskEntityB();
+        taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityB);
+
+
+        TaskGroupEntity testTaskGroupEntityB = TestDataUtil.createTaskGroupEntityB();
+        taskGroupService.save(testTaskGroupEntityB);
+        TaskEntity testTaskEntityC = TestDataUtil.createTestTaskEntityB();
+        taskService.createTask(testTaskGroupEntityB.getId(), testTaskEntityC);
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/taskgroups/" + testTaskGroupEntityA.getId() + "/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(
+            MockMvcResultMatchers.status().isNoContent()
+        );
+        
+        List<TaskEntity> result = taskService.findAll();
+        assertThat(result).extracting(TaskEntity::getId).containsExactly(testTaskEntityC.getId());
+    }
 }

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
@@ -250,10 +250,38 @@ public class TaskGroupControllerIntegrationTests {
         );
     }
 
-    // TODO 
-    // - Update task group name etc
-    // - DELETE all tasks
-    // - 
+
+    @Test
+    public void testThatUpdateTaskGroupKeepsItsTasks() throws Exception{
+        TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
+        taskGroupService.save(testTaskGroupEntityA);
+
+        TaskEntity testTaskEntityA = TestDataUtil.createTestTaskEntityA();
+        taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityA);
+
+        assertThat(taskGroupService.findByIdWithTasks(testTaskGroupEntityA.getId()).getTasks())
+                            .extracting(TaskEntity::getId)
+                            .containsExactly(testTaskEntityA.getId());
+
+        TaskGroupRequestDto testTaskGroupDtoA = TestDataUtil.createTaskGroupDtoA();
+        testTaskGroupDtoA.setTaskGroupName("UPDATED");
+        String taskGroupJson = objectMapper.writeValueAsString(testTaskGroupDtoA);
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.patch("/taskgroups/" + testTaskGroupEntityA.getId())
+                .contentType(MediaType.APPLICATION_JSON)   
+                .content(taskGroupJson) 
+        ).andExpect(
+            MockMvcResultMatchers.status().isOk()
+        ).andExpect(
+            MockMvcResultMatchers.jsonPath("$.taskGroupName").value("UPDATED")
+        );
+
+        assertThat(taskGroupService.findByIdWithTasks(testTaskGroupEntityA.getId()).getTasks())
+                            .extracting(TaskEntity::getId)
+                            .containsExactly(testTaskEntityA.getId());
+    }
+
 
     @Test
     public void testThatDeleteAllTasksDeletesCorrespondingTasks() throws Exception{

--- a/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
+++ b/src/test/java/com/jonassavas/spring_task_api/controllers/TaskGroupControllerIntegrationTests.java
@@ -16,14 +16,12 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jonassavas.spring_task_api.TestDataUtil;
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskDto;
-import com.jonassavas.spring_task_api.domain.dto.CreateTaskGroupDto;
+import com.jonassavas.spring_task_api.domain.dto.TaskGroupRequestDto;
 import com.jonassavas.spring_task_api.domain.entities.TaskEntity;
 import com.jonassavas.spring_task_api.domain.entities.TaskGroupEntity;
 import com.jonassavas.spring_task_api.services.TaskGroupService;
 import com.jonassavas.spring_task_api.services.TaskService;
 
-import jakarta.transaction.Transactional;
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -73,8 +71,6 @@ public class TaskGroupControllerIntegrationTests {
             .contentType(MediaType.APPLICATION_JSON)
             .content(taskGroupJson)
         ).andExpect(
-            MockMvcResultMatchers.jsonPath("$.id").isNumber()
-        ).andExpect(
             MockMvcResultMatchers.jsonPath("$.taskGroupName").value("Task Group A")
         );
     }
@@ -123,7 +119,6 @@ public class TaskGroupControllerIntegrationTests {
     }
     
 
-    @Transactional
     @Test
     public void testThatDeleteTaskGroupDeletesCorrectGroup() throws Exception{
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
@@ -148,7 +143,6 @@ public class TaskGroupControllerIntegrationTests {
                 .containsExactly(testTaskGroupEntityB.getId());
     }
 
-    @Transactional
     @Test
     public void testThatDeleteTaskGroupDeletesTasks() throws Exception{
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
@@ -161,7 +155,7 @@ public class TaskGroupControllerIntegrationTests {
         TaskEntity testTaskEntityC = TestDataUtil.createTestTaskEntityC();
         taskService.createTask(testTaskGroupEntityA.getId(), testTaskEntityC);
 
-        List<TaskGroupEntity> result = taskGroupService.findAll();
+        List<TaskGroupEntity> result = taskGroupService.findAllWithTasks();
         assertThat(result.size()).isEqualTo(1); 
         assertThat(result.getFirst().getTasks())
                                     .extracting(TaskEntity::getId)
@@ -181,12 +175,11 @@ public class TaskGroupControllerIntegrationTests {
             MockMvcResultMatchers.status().isNoContent()
         );
         
-        assertThat(taskGroupService.findAll().size()).isEqualTo(0);
+        assertThat(taskGroupService.findAllWithTasks().size()).isEqualTo(0);
         assertThat(taskService.findAll().size()).isEqualTo(0);
     }
 
 
-    @Transactional
     @Test
     public void testThatDeleteTaskGroupOnlyDeletesOwnTasks() throws Exception{
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
@@ -203,7 +196,7 @@ public class TaskGroupControllerIntegrationTests {
         TaskEntity testTaskEntityC = TestDataUtil.createTestTaskEntityC();
         taskService.createTask(testTaskGroupEntityB.getId(), testTaskEntityC);
 
-        List<TaskGroupEntity> result = taskGroupService.findAll();
+        List<TaskGroupEntity> result = taskGroupService.findAllWithTasks();
         assertThat(result.size()).isEqualTo(2); 
         assertThat(result.get(0).getTasks())
                                     .extracting(TaskEntity::getId)
@@ -225,7 +218,7 @@ public class TaskGroupControllerIntegrationTests {
             MockMvcResultMatchers.status().isNoContent()
         );
 
-        result = taskGroupService.findAll();
+        result = taskGroupService.findAllWithTasks();
         assertThat(result.size()).isEqualTo(1);
         assertThat(result)
                 .extracting(TaskGroupEntity::getId)
@@ -242,7 +235,7 @@ public class TaskGroupControllerIntegrationTests {
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
         taskGroupService.save(testTaskGroupEntityA);
 
-        CreateTaskGroupDto testTaskGroupDtoA = TestDataUtil.createTaskGroupDtoA();
+        TaskGroupRequestDto testTaskGroupDtoA = TestDataUtil.createTaskGroupDtoA();
         testTaskGroupDtoA.setTaskGroupName("UPDATED");
         String taskGroupJson = objectMapper.writeValueAsString(testTaskGroupDtoA);
 
@@ -263,7 +256,6 @@ public class TaskGroupControllerIntegrationTests {
     // - 
 
     @Test
-    //@Transactional
     public void testThatDeleteAllTasksDeletesCorrespondingTasks() throws Exception{
         TaskGroupEntity testTaskGroupEntityA = TestDataUtil.createTaskGroupEntityA();
         taskGroupService.save(testTaskGroupEntityA);


### PR DESCRIPTION
Fixes: #5, #9 

Adds all the required CRUD functionality for Tasks & TaskGroups. Improves DTO-naming and improves the service-layer by adding ```@Transactional``` annotations on the service-layer implementation classes to consistently flush to the database upon method-exits.